### PR TITLE
Display max and current throughput

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,28 @@
+# Throughput Analyzer Mod Plan
+
+## Overall Goals
+- Provide a tool that allows a player to select an area and analyze the throughput of machines, belts, and inserters within that area.
+- Display throughput data in a GUI and highlight potential bottlenecks.
+- Iteratively expand functionality as the mod evolves.
+
+## Implementation Checklist
+- [x] Create base mod folder with `info.json`, `data.lua`, and basic prototypes
+- [x] Implement selection tool prototype and localization
+- [x] Register selection tool events in `control.lua`
+- [x] On selection, scan entities and compute simple throughput metrics
+- [x] Display results in a basic GUI table
+- [x] Show max vs actual throughput for each entity
+- [x] Switch to built-in icon to avoid binary files in repo
+- [ ] Identify and highlight bottlenecks
+- [ ] Incrementally refine analysis logic and GUI
+
+## Rationales
+- **Base mod structure** ensures Factorio can load the mod.
+- **Selection tool** lets players choose an area similar to blueprint tools.
+- **Event handling** is required to react when players use the tool.
+- **Throughput calculations** provide the core functionality—measuring production rates and belt speeds.
+- **GUI display** communicates results to the player in-game.
+- **Bottleneck detection** helps players optimize their factories.
+- **Iterative updates** allow gradual enhancement of features and accuracy.
+- **Max vs actual throughput** reveals inefficiencies in production.
+- **Built-in icon** avoids storing unsupported binary files.

--- a/throughput-analyzer/data.lua
+++ b/throughput-analyzer/data.lua
@@ -1,0 +1,1 @@
+require("prototypes.item")

--- a/throughput-analyzer/info.json
+++ b/throughput-analyzer/info.json
@@ -1,0 +1,8 @@
+{
+  "name": "throughput-analyzer",
+  "version": "0.1.0",
+  "title": "Throughput Analyzer",
+  "author": "OpenAI",
+  "factorio_version": "2.0",
+  "description": "Analyze throughput of machines, belts and inserters in a selected area."
+}

--- a/throughput-analyzer/locale/en/locale.cfg
+++ b/throughput-analyzer/locale/en/locale.cfg
@@ -1,0 +1,5 @@
+[item-name]
+throughput-analyzer-tool=Throughput Analyzer
+
+[item-description]
+throughput-analyzer-tool=Select an area to analyze machine and belt throughput.

--- a/throughput-analyzer/prototypes/item.lua
+++ b/throughput-analyzer/prototypes/item.lua
@@ -1,0 +1,21 @@
+-- Use a base game icon to avoid shipping a binary placeholder
+local icon_path = "__base__/graphics/icons/blueprint.png"
+
+data:extend({
+  {
+    type = "selection-tool",
+    name = "throughput-analyzer-tool",
+    icon = icon_path,
+    icon_size = 64,
+    flags = {"goes-to-main-inventory"},
+    subgroup = "tool",
+    order = "c[automated-construction]-a[analyzer]",
+    stack_size = 1,
+    selection_color = {r=0, g=1, b=0},
+    alt_selection_color = {r=0, g=1, b=0},
+    selection_mode = {"any-entity"},
+    alt_selection_mode = {"any-entity"},
+    selection_cursor_box_type = "entity",
+    alt_selection_cursor_box_type = "entity"
+  }
+})


### PR DESCRIPTION
## Summary
- update mod plan with step for max vs. actual throughput
- rework `control.lua` to compute max capacity and current rate for entities
- extend GUI to show these values
- use base blueprint icon instead of PNG placeholder to avoid binary files

## Testing
- `luacheck throughput-analyzer/control.lua` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6844459122448323a832a2139cfe4a15