### PR TITLE
Improve luacheck cleanliness

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,4 @@
+std = "lua51"
+read_globals = {"data", "game", "script", "defines"}
+unused_args = false
+max_line_length = 120

--- a/throughput-analyzer/control.lua
+++ b/throughput-analyzer/control.lua
@@ -1,3 +1,5 @@
+-- luacheck: globals script game defines
+
 local ANALYZER_NAME = "throughput-analyzer-tool"
 
 local function analyze_entity(entity)
@@ -49,7 +51,12 @@ local function show_gui(player, results)
     player.gui.screen.throughput_analyzer_frame.destroy()
   end
 
-  local frame = player.gui.screen.add{type="frame", name="throughput_analyzer_frame", caption="Throughput Analysis", direction="vertical"}
+  local frame = player.gui.screen.add{
+    type = "frame",
+    name = "throughput_analyzer_frame",
+    caption = "Throughput Analysis",
+    direction = "vertical"
+  }
   frame.auto_center = true
 
   local table_elem = frame.add{type="table", column_count=4}

--- a/throughput-analyzer/prototypes/item.lua
+++ b/throughput-analyzer/prototypes/item.lua
@@ -1,3 +1,4 @@
+-- luacheck: globals data
 -- Use a base game icon to avoid shipping a binary placeholder
 local icon_path = "__base__/graphics/icons/blueprint.png"
 


### PR DESCRIPTION
## Summary
- add `.luacheckrc`
- mark Factorio globals in Lua scripts
- wrap long GUI frame construction line

## Testing
- `luacheck throughput-analyzer/*.lua throughput-analyzer/prototypes/*.lua --no-color`

------
https://chatgpt.com/codex/tasks/task_e_68444ddc3b748323868505eef40c771a