### PR TITLE
Fix invalid item flag in Factorio mod

### DIFF
--- a/throughput-analyzer/prototypes/item.lua
+++ b/throughput-analyzer/prototypes/item.lua
@@ -9,7 +9,6 @@ data:extend({
     name = "throughput-analyzer-tool",
     icon = icon_path,
     icon_size = 64,
-    flags = {"goes-to-main-inventory"},
     subgroup = "tool",
     order = "c[automated-construction]-a[analyzer]",
     stack_size = 1,


### PR DESCRIPTION
## Summary
- remove unrecognized `goes-to-main-inventory` flag from selection tool prototype

## Testing
- `luacheck throughput-analyzer`

------
https://chatgpt.com/codex/tasks/task_e_68445886cd9483239d25b0540738ef8b