### PR TITLE
Ensure analyzer tool appears

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -13,7 +13,7 @@ This document outlines how to verify the **Throughput Analyzer** Factorio mod in
 
 ## In‑Game Testing Steps
 1. Start a new game or load an existing save.
-2. Locate the **Throughput Analyzer** tool in your inventory.
+2. Locate the **Throughput Analyzer** tool in your inventory. The mod automatically places one in each player's inventory when it loads.
 3. Select the tool, then drag over a small area containing a few machines, transport belts and inserters.
 4. Upon releasing the mouse button, a window titled **Throughput Analysis** should appear.
 5. Verify the window lists each selected entity with columns for **Name**, **Type**, **Max**, and **Current** values.

--- a/throughput-analyzer/README.md
+++ b/throughput-analyzer/README.md
@@ -7,6 +7,8 @@ This folder contains the actual Factorio mod.
 1. Copy the `throughput-analyzer` directory into your Factorio `mods` folder.
 2. Start the game and enable the mod.
 
+When the mod is active, each player is automatically given the **Throughput Analyzer** tool. Look for it in the *Tools* tab of your inventory.
+
 ## Usage
 
 Select the *Throughput Analyzer* tool from your inventory and drag over an area of machines.

--- a/throughput-analyzer/control.lua
+++ b/throughput-analyzer/control.lua
@@ -16,8 +16,30 @@ local function debug_log(msg)
   if verbose then log("[TA] " .. msg) end
 end
 
-script.on_init(update_verbose)
-script.on_configuration_changed(update_verbose)
+local function give_tool(player)
+  if player and player.valid then
+    local inv = player.get_main_inventory()
+    if inv and not inv.find_item_stack(ANALYZER_NAME) then
+      inv.insert{name = ANALYZER_NAME, count = 1}
+    end
+  end
+end
+
+local function give_tool_all_players()
+  for _, p in pairs(game.players) do
+    give_tool(p)
+  end
+end
+
+script.on_init(function()
+  update_verbose()
+  give_tool_all_players()
+end)
+
+script.on_configuration_changed(function()
+  update_verbose()
+  give_tool_all_players()
+end)
 script.on_event(defines.events.on_runtime_mod_setting_changed, function(event)
   if event.setting == "throughput-analyzer-verbose" then
     update_verbose()
@@ -125,4 +147,9 @@ script.on_event(defines.events.on_gui_click, function(event)
       frame.destroy()
     end
   end
+end)
+
+script.on_event(defines.events.on_player_created, function(event)
+  local player = game.players[event.player_index]
+  give_tool(player)
 end)


### PR DESCRIPTION
## Summary
- automatically add the analyzer tool to each player's inventory
- explain inventory placement in the mod README
- clarify testing guide

## Testing
- `luacheck throughput-analyzer`

------
https://chatgpt.com/codex/tasks/task_e_68446248b9948323b5d1205898332081