### PR TITLE
Add deploy script to install mod version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ The mod itself lives in the `throughput-analyzer` directory and can be copied di
 - `throughput-analyzer/` – the mod files loaded by Factorio
 - `plan.md` – high level development roadmap
 
+## Deployment Helper
+
+The `deploy_mod.py` script automates installing the mod into your local
+Factorio `mods` folder. Provide a new version number and it will update
+`throughput-analyzer/info.json`, remove any old copies of the mod and copy the
+folder with the version appended to its name. Example:
+
+```bash
+python deploy_mod.py 0.1.1
+```
+
+Use `--mods-dir` to override the default path of
+`C:\Users\shake\AppData\Roaming\Factorio\mods`.
+
 The project is released under the MIT License found in `LICENSE`.
 
 ## Debug Logging

--- a/deploy_mod.py
+++ b/deploy_mod.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Deploy the Factorio mod to the user's mods directory with a new version.
+
+This script updates `throughput-analyzer/info.json` with the provided version,
+removes any existing copies of the mod from the destination mods folder, and
+copies the mod folder there with the version appended to the directory name.
+"""
+import argparse
+import json
+import os
+import shutil
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Deploy the Throughput Analyzer mod")
+    parser.add_argument(
+        "version",
+        help="New version number, e.g. 0.1.1",
+    )
+    parser.add_argument(
+        "--mods-dir",
+        default=r"C:\\Users\\shake\\AppData\\Roaming\\Factorio\\mods",
+        help="Path to the Factorio mods directory",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent
+    mod_src = repo_root / "throughput-analyzer"
+    info_path = mod_src / "info.json"
+
+    # Update info.json version
+    with info_path.open("r", encoding="utf-8") as f:
+        info = json.load(f)
+    old_version = info.get("version")
+    info["version"] = args.version
+    with info_path.open("w", encoding="utf-8") as f:
+        json.dump(info, f, indent=2)
+        f.write("\n")
+    print(f"Updated version: {old_version} -> {args.version}")
+
+    mods_dir = Path(os.path.expanduser(args.mods_dir))
+    if not mods_dir.is_dir():
+        raise FileNotFoundError(f"Mods directory not found: {mods_dir}")
+
+    # Remove any existing copies of the mod
+    for entry in mods_dir.iterdir():
+        if entry.name.startswith("throughput-analyzer"):
+            if entry.is_dir():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+            print(f"Removed {entry}")
+
+    dest_name = f"throughput-analyzer_{args.version}"
+    dest_path = mods_dir / dest_name
+    shutil.copytree(mod_src, dest_path)
+    print(f"Copied {mod_src} -> {dest_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `deploy_mod.py` for installing the mod into the Factorio mods directory
- document usage of the deployment script in `README.md`

## Testing
- `luacheck throughput-analyzer`
- `python -m py_compile deploy_mod.py`


------
https://chatgpt.com/codex/tasks/task_e_68446522e9d08323a6d9b3d71dc9aa9f