### PR TITLE
Fix safe_string for Factorio 2.0

### DIFF
--- a/throughput-analyzer/control.lua
+++ b/throughput-analyzer/control.lua
@@ -20,11 +20,19 @@ end
 
 local function safe_string(val)
   if type(val) == "table" then
-    if game and game.table_to_json then
-      return game.table_to_json(val)
-    else
-      return "[table]"
+    if game then
+      local ok, result = pcall(function()
+        if game.table_to_json then
+          return game.table_to_json(val)
+        elseif game.table_to_string then
+          return game.table_to_string(val)
+        end
+      end)
+      if ok and result then
+        return result
+      end
     end
+    return "[table]"
   end
   return tostring(val)
 end


### PR DESCRIPTION
## Summary
- avoid crash when `table_to_json` is missing
- fall back to Factorio's `table_to_string` if available

## Testing
- `luacheck throughput-analyzer`
- `python -m py_compile deploy_mod.py`

------
https://chatgpt.com/codex/tasks/task_e_68449d3fb1388323bba0702b75ac6456